### PR TITLE
What about non field errors?

### DIFF
--- a/bootstrapform/templates/bootstrapform/form.html
+++ b/bootstrapform/templates/bootstrapform/form.html
@@ -1,4 +1,11 @@
-{{ form.non_field_errors }}
+{% if form.non_field_errors %}
+    <div class="alert alert-error">
+        <a class="close" data-dismiss="alert">&times;</a></a>
+        {% for non_field_error in form.non_field_errors %}
+             {{ non_field_error }}
+        {% endfor %}
+    </div>
+{% endif %}
 
 {% for field in form.hidden_fields %}
     {{ field }}


### PR DESCRIPTION
Non field errors shown as bootstrap alerts looks much better than default Django &lt;ul&gt;s.
Though this thing needs an alert plugin which I think is not included by default.
