### PR TITLE
Handling formsets

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -7,12 +7,19 @@ register = template.Library()
 @register.filter
 def bootstrap(element):
     element_type = element.__class__.__name__.lower()
+
     if element_type == 'boundfield':
         template = get_template("bootstrapform/field.html")
         context = Context({'field': element})
     else:
-        template = get_template("bootstrapform/form.html")
-        context = Context({'form': element})
+        has_management = getattr(element, 'management_form', None)
+        print "has management", has_management
+        if has_management:
+            template = get_template("bootstrapform/formset.html")
+            context = Context({'formset': element})
+        else:
+            template = get_template("bootstrapform/form.html")
+            context = Context({'form': element})
         
     return template.render(context)
 

--- a/bootstrapform/templatetags/formset.html
+++ b/bootstrapform/templatetags/formset.html
@@ -1,0 +1,5 @@
+{{ formset.management_form }}
+{% for form in formset %}
+    {% include "bootstrapform/form.html" with form=form %}
+{% endfor %}
+


### PR DESCRIPTION
Modified bootstrap.py to handle formsets (looks for the attribute management_form, probably there is a better way).

added templates/formset.html. Basically outputs the management form and cycles on forms rendering them with the form template
