### PR TITLE
Fix behavior for auto_id=False on form creation

### DIFF
--- a/bootstrapform/templates/bootstrapform/field.html
+++ b/bootstrapform/templates/bootstrapform/field.html
@@ -4,10 +4,11 @@
     {% if field|is_checkbox %}
         <div class="{{ classes.single_value }}">
             <div class="checkbox">
+                {% if field.auto_id %}
                 <label>
                     {{ field }} <span>{{ field.label }}</span>
                 </label>
-
+                {% endif %}
                 {% for error in field.errors %}
                     <span class="help-block">{{ error }}</span>
                 {% endfor %}
@@ -20,8 +21,9 @@
             </div>
         </div>
     {% else %}{% if field|is_radio %}
-        <label class="control-label {{ classes.label }}">{{ field.label }}</label>
-
+        {% if field.auto_id %}
+            <label class="control-label {{ classes.label }}">{{ field.label }}</label>
+        {% endif %}
         <div class="{{ classes.value }}">
             {% for choice in field %}
                 <div class="radio">
@@ -44,8 +46,9 @@
         </div>
 
     {% else %}
-        <label class="control-label {{ classes.label }}" for="{{ field.auto_id }}">{{ field.label }}</label>
-
+        {% if field.auto_id %}
+            <label class="control-label {{ classes.label }}" for="{{ field.auto_id }}">{{ field.label }}</label>
+        {% endif %}
         <div class="{{ classes.value }}">
             {{ field }}
 


### PR DESCRIPTION
Hi,

thanks for this easy way to integrate bootstrapped forms with Django!

This fixes the behavior for bootstrapped form fields to match the behavior described in the Django docs here: 

> If auto_id is False, then the form output will not include <label> tags nor id attributes
> (https://docs.djangoproject.com/en/dev/ref/forms/api/#ref-forms-api-configuring-label)

best regards,
Jan
