### PR TITLE
Use isinstance for checking widget types

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.template import Context
 from django.template.loader import get_template
 from django import template
@@ -82,14 +83,14 @@ def render(element, markup_classes):
 
 @register.filter
 def is_checkbox(field):
-    return field.field.widget.__class__.__name__.lower() == "checkboxinput"
+    return isinstance(field.field.widget, forms.CheckboxInput)
 
 
 @register.filter
 def is_multiple_checkbox(field):
-    return field.field.widget.__class__.__name__.lower() == "checkboxselectmultiple"
+    return isinstance(field.field.widget, forms.CheckboxSelectMultiple)
 
 
 @register.filter
 def is_radio(field):
-    return field.field.widget.__class__.__name__.lower() == "radioselect"
+    return isinstance(field.field.widget, forms.RadioSelect)


### PR DESCRIPTION
Hi,

when checking for widget types by class name, custom subclassed widgets aren't rendered properly. This approach is a bit more flexible.

Cheers,
Patrick
