### PR TITLE
Handle empty fields gracefully

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -57,7 +57,9 @@ def add_input_classes(field):
 def render(element, markup_classes):
     element_type = element.__class__.__name__.lower()
 
-    if element_type == 'boundfield':
+    if element == "":
+        return None
+    elif element_type == 'boundfield':
         add_input_classes(element)
         template = get_template("bootstrapform/field.html")
         context = Context({'field': element, 'classes': markup_classes})


### PR DESCRIPTION
Currently the `|bootstrap` templatetag causes an exception to be fired
if used on an undefined form element. I've changed it to just return
None if the element is empty.
