### PR TITLE
Add possibility to manually display non field errors

### DIFF
--- a/bootstrapform/templates/bootstrapform/errors.html
+++ b/bootstrapform/templates/bootstrapform/errors.html
@@ -1,0 +1,8 @@
+{% if errors %}
+    <div class="alert alert-danger">
+        <a class="close" data-dismiss="alert">&times;</a>
+        {% for error in errors %}
+             {{ error }}
+        {% endfor %}
+    </div>
+{% endif %}

--- a/bootstrapform/templates/bootstrapform/form.html
+++ b/bootstrapform/templates/bootstrapform/form.html
@@ -1,11 +1,6 @@
-{% if form.non_field_errors %}
-    <div class="alert alert-danger">
-        <a class="close" data-dismiss="alert">&times;</a>
-        {% for non_field_error in form.non_field_errors %}
-             {{ non_field_error }}
-        {% endfor %}
-    </div>
-{% endif %}
+{% with errors=form.non_field_errors %}
+    {% include 'bootstrapform/errors.html' %}
+{% endwith %}
 
 {% for field in form.hidden_fields %}
     {{ field }}

--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -59,12 +59,13 @@ def add_input_classes(field):
 
 
 def render(element, markup_classes):
-    element_type = element.__class__.__name__.lower()
-
-    if element_type == 'boundfield':
+    if isinstance(element, forms.forms.BoundField):
         add_input_classes(element)
         template = get_template("bootstrapform/field.html")
         context = Context({'field': element, 'classes': markup_classes})
+    elif isinstance(element, forms.forms.ErrorList):
+        template = get_template("bootstrapform/errors.html")
+        context = Context({'errors': element})
     else:
         has_management = getattr(element, 'management_form', None)
         if has_management:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -52,9 +52,12 @@ Usage
     # or use with individual field
     {{ form.<field name>|bootstrap }} - To output individual fields
 
+    # in this case you have to manually include non field errors:
+    {{ form.non_field_errors|bootstrap }}
+
     # For horizontal forms
     {{ form|bootstrap_horizontal }}
-    
+
     # Or with custom size (default is 'col-lg-2 col-sm-2')
     {{ form|bootstrap_horizontal:'col-lg-4' }}
 


### PR DESCRIPTION
When rendering single fields, there is no way to display the non_field_errors automatically with bootstrap markup. With this patch it's possible to include them like this:

```
{{ form.non_field_errors|bootstrap }}
```
