### PR TITLE
Fix dict created at compile time in bootstrap_horizontal

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -20,13 +20,9 @@ def bootstrap_inline(element):
 
 
 @register.filter
-def bootstrap_horizontal(element, label_cols={}):
-    if not label_cols:
-        label_cols = 'col-sm-2 col-lg-2'
+def bootstrap_horizontal(element, label_cols='col-sm-2 col-lg-2'):
 
-    markup_classes = {'label': label_cols,
-            'value': '',
-            'single_value': ''}
+    markup_classes = {'label': label_cols, 'value': '', 'single_value': ''}
 
     for cl in label_cols.split(' '):
         splited_class = cl.split('-')


### PR DESCRIPTION
It's a usual pitfall in Python to instanciate an object as default value in function.

http://stackoverflow.com/questions/530530/python-2-x-gotchas-and-landmines