### PR TITLE
Reducing if statements in templates/form.html

### DIFF
--- a/bootstrapform/templates/bootstrapform/formset.html
+++ b/bootstrapform/templates/bootstrapform/formset.html
@@ -1,15 +1,11 @@
 {{ formset.management_form }}
 
 {% for form in formset %}
-
   {% if classes.label == 'sr-only' %}
       <div class="form-inline">
+      {% include "bootstrapform/form.html" with form=form %}
+      </div>
+  {%else%}
+      {% include "bootstrapform/form.html" with form=form %}
   {% endif %}
-
-    {% include "bootstrapform/form.html" with form=form %}
-
-  {% if classes.label == 'sr-only' %}
-     </div>
-  {% endif %}
-
 {% endfor %}


### PR DESCRIPTION
Doing it once reduces complexity making the code faster while rendering.
Also since the check is done on a high level like templates, it is slower than
the native python if condition. Thus the need to reduce checks on the higher levels.