### PR TITLE
Fix deprecation warnings on Django 1.9

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -1,3 +1,4 @@
+import django
 from django import forms
 from django.template import Context
 from django.template.loader import get_template
@@ -60,7 +61,7 @@ def render(element, markup_classes):
     if element_type == 'boundfield':
         add_input_classes(element)
         template = get_template("bootstrapform/field.html")
-        context = Context({'field': element, 'classes': markup_classes, 'form': element.form})
+        context = {'field': element, 'classes': markup_classes, 'form': element.form}
     else:
         has_management = getattr(element, 'management_form', None)
         if has_management:
@@ -69,13 +70,16 @@ def render(element, markup_classes):
                     add_input_classes(field)
 
             template = get_template("bootstrapform/formset.html")
-            context = Context({'formset': element, 'classes': markup_classes})
+            context = {'formset': element, 'classes': markup_classes}
         else:
             for field in element.visible_fields():
                 add_input_classes(field)
 
             template = get_template("bootstrapform/form.html")
-            context = Context({'form': element, 'classes': markup_classes})
+            context = {'form': element, 'classes': markup_classes}
+
+    if django.VERSION[0] * 1000 + django.VERSION[1] < 1008:
+        context = Context(context)
 
     return template.render(context)
 


### PR DESCRIPTION
On latest Django version, 1.9, there is a deprecation warning against sending Context() to backend specific Template classes which have a slightly different signature than earlier.  https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/#django-template-loader 

This pull request fixes that while trying to keep compatibility with Django < 1.8.
