### PR TITLE
Better check for whether element is field or form.

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -55,9 +55,7 @@ def add_input_classes(field):
 
 
 def render(element, markup_classes):
-    element_type = element.__class__.__name__.lower()
-
-    if element_type == 'boundfield':
+    if isinstance(element, forms.forms.BoundField):
         add_input_classes(element)
         template = get_template("bootstrapform/field.html")
         context = Context({'field': element, 'classes': markup_classes, 'form': element.form})


### PR DESCRIPTION
Using `isinstance(element, forms.forms.BoundField)` instead of using `element_type = element.__class__.__name__.lower()`. Also works when subclassing BoundField (in my use case with Django-Angular.)