### PR TITLE
moved out template names to bootstrapform.config to be able to safely…

### DIFF
--- a/bootstrapform/config.py
+++ b/bootstrapform/config.py
@@ -1,4 +1,6 @@
 from django.conf import settings
 
-
 BOOTSTRAP_COLUMN_COUNT = getattr(settings, 'BOOTSTRAP_COLUMN_COUNT', 12)
+BOOTSTRAP_FIELD_TEMPLATE = getattr(settings, 'BOOTSTRAP_FIELD_TEMPLATE', 'bootstrapform/field.html')
+BOOTSTRAP_FORMSET_TEMPLATE = getattr(settings, 'BOOTSTRAP_FORMSET_TEMPLATE', 'bootstrapform/formset.html')
+BOOTSTRAP_FORM_TEMPLATE = getattr(settings, 'BOOTSTRAP_FORM_TEMPLATE', 'bootstrapform/form.html')

--- a/bootstrapform/templates/bootstrapform/field.html
+++ b/bootstrapform/templates/bootstrapform/field.html
@@ -5,7 +5,7 @@
         <div class="{{ classes.single_value }}">
             <div class="checkbox">
                 {% if field.auto_id %}
-                    <label {% if field.field.required and form.required_css_class %}class="{{ form.required_css_class }}"{% endif %}>
+                    <label {% if field.field.required %}class="{{ form.required_css_class }}"{% endif %}>
                         {{ field }} <span>{{ field.label }}</span>
                     </label>
                 {% endif %}

--- a/bootstrapform/templates/bootstrapform/form.html
+++ b/bootstrapform/templates/bootstrapform/form.html
@@ -12,5 +12,5 @@
 {% endfor %}
 
 {% for field in form.visible_fields %}
-    {% include 'bootstrapform/field.html' %}
+    {% include field_template %}
 {% endfor %}

--- a/bootstrapform/templates/bootstrapform/formset.html
+++ b/bootstrapform/templates/bootstrapform/formset.html
@@ -3,9 +3,9 @@
 {% for form in formset %}
   {% if classes.label == 'sr-only' %}
       <div class="form-inline">
-      {% include "bootstrapform/form.html" with form=form %}
+      {% include form_template with form=form %}
       </div>
   {%else%}
-      {% include "bootstrapform/form.html" with form=form %}
+      {% include form_template with form=form %}
   {% endif %}
 {% endfor %}

--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -56,11 +56,16 @@ def add_input_classes(field):
 
 def render(element, markup_classes):
     element_type = element.__class__.__name__.lower()
+    common_context = {
+        'field_template': config.BOOTSTRAP_FIELD_TEMPLATE,
+        'form_template': config.BOOTSTRAP_FORM_TEMPLATE,
+        'formset_template': config.BOOTSTRAP_FORMSET_TEMPLATE,
+    }
 
     if element_type == 'boundfield':
         add_input_classes(element)
-        template = get_template("bootstrapform/field.html")
-        context = Context({'field': element, 'classes': markup_classes, 'form': element.form})
+        template = get_template(config.BOOTSTRAP_FIELD_TEMPLATE)
+        context = Context(dict(common_context, **{'field': element, 'classes': markup_classes, 'form': element.form}))
     else:
         has_management = getattr(element, 'management_form', None)
         if has_management:
@@ -68,14 +73,14 @@ def render(element, markup_classes):
                 for field in form.visible_fields():
                     add_input_classes(field)
 
-            template = get_template("bootstrapform/formset.html")
-            context = Context({'formset': element, 'classes': markup_classes})
+            template = get_template(config.BOOTSTRAP_FORMSET_TEMPLATE)
+            context = Context(dict(common_context, **{'formset': element, 'classes': markup_classes}))
         else:
             for field in element.visible_fields():
                 add_input_classes(field)
 
-            template = get_template("bootstrapform/form.html")
-            context = Context({'form': element, 'classes': markup_classes})
+            template = get_template(config.BOOTSTRAP_FORM_TEMPLATE)
+            context = Context(dict(common_context, **{'form': element, 'classes': markup_classes}))
 
     return template.render(context)
 

--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -68,6 +68,8 @@ def render(element, markup_classes):
         context = Context(dict(common_context, **{'field': element, 'classes': markup_classes, 'form': element.form}))
     else:
         has_management = getattr(element, 'management_form', None)
+        if not hasattr(element, 'required_css_class'):
+            element.required_css_class = 'required'
         if has_management:
             for form in element.forms:
                 for field in form.visible_fields():


### PR DESCRIPTION
… be able to modify the templates without having to mixture with django template finder

We are using the official bootstrap themes from http://themes.getbootstrap.com/, and to get some of the functionality we have to make changes in the bootstrapform/templates. But to be able to do this, without having to either have the apps in a certain order, or modify djangos template loader, we need to explicitly be able to set the template that is used for form/formset/field.

The changes basically just reads from settings, and defaults to the values as before this PR.
