### PR TITLE
Fixing: Deprecation warnings when used with Django 1.9 #77

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -1,4 +1,4 @@
-from django import forms
+from django import forms, VERSION as django_version
 from django.template import Context
 from django.template.loader import get_template
 from django import template
@@ -76,6 +76,9 @@ def render(element, markup_classes):
 
             template = get_template("bootstrapform/form.html")
             context = Context({'form': element, 'classes': markup_classes})
+
+        if django_version >= (1, 8):
+            context = context.flatten()
 
     return template.render(context)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34}-dj{15,16,17,18}
+envlist = {py27,py34}-dj{15,16,17,18,19}
 skipsdist=True
 
 
@@ -13,6 +13,7 @@ deps =
     dj16: django>=1.6,<1.7
     dj17: django>=1.7,<1.8
     dj18: django>=1.8,<1.9
+    dj19: django>=1.9,<1.10
 commands = python setup.py test
 
 


### PR DESCRIPTION
Fixing: Deprecation warnings when used with Django 1.9 #77