### PR TITLE
Change "file_fied" to "file_field"

### DIFF
--- a/bootstrapform/fixtures/basic.html
+++ b/bootstrapform/fixtures/basic.html
@@ -65,10 +65,10 @@
 </div>
 
 <div class="form-group">
-    <label class="control-label  " for="id_file_fied">File fied</label>
+    <label class="control-label  " for="id_file_field">File field</label>
 
     <div class=" ">
-        <input id="id_file_fied" name="file_fied" type="file" />
+        <input id="id_file_field" name="file_field" type="file" />
     </div>
 </div>
 

--- a/bootstrapform/fixtures/basic_dj16.html
+++ b/bootstrapform/fixtures/basic_dj16.html
@@ -65,10 +65,10 @@
 </div>
 
 <div class="form-group">
-    <label class="control-label  " for="id_file_fied">File fied</label>
+    <label class="control-label  " for="id_file_field">File field</label>
 
     <div class=" ">
-        <input id="id_file_fied" name="file_fied" type="file" />
+        <input id="id_file_field" name="file_field" type="file" />
     </div>
 </div>
 

--- a/bootstrapform/fixtures/basic_old.html
+++ b/bootstrapform/fixtures/basic_old.html
@@ -65,10 +65,10 @@
 </div>
 
 <div class="form-group">
-    <label class="control-label  " for="id_file_fied">File fied</label>
+    <label class="control-label  " for="id_file_field">File field</label>
 
     <div class=" ">
-        <input id="id_file_fied" name="file_fied" type="file" />
+        <input id="id_file_field" name="file_field" type="file" />
     </div>
 </div>
 

--- a/bootstrapform/fixtures/horizontal.html
+++ b/bootstrapform/fixtures/horizontal.html
@@ -67,10 +67,10 @@
 </div>
 
 <div class="form-group">
-    <label class="control-label col-sm-2 col-lg-2 " for="id_file_fied">File fied</label>
+    <label class="control-label col-sm-2 col-lg-2 " for="id_file_field">File field</label>
     
     <div class=" col-sm-10 col-lg-10 ">
-        <input id="id_file_fied" name="file_fied" type="file" />
+        <input id="id_file_field" name="file_field" type="file" />
     </div>
 </div>
 

--- a/bootstrapform/fixtures/horizontal_dj16.html
+++ b/bootstrapform/fixtures/horizontal_dj16.html
@@ -67,10 +67,10 @@
 </div>
 
 <div class="form-group">
-    <label class="control-label col-sm-2 col-lg-2 " for="id_file_fied">File fied</label>
+    <label class="control-label col-sm-2 col-lg-2 " for="id_file_field">File field</label>
     
     <div class=" col-sm-10 col-lg-10 ">
-        <input id="id_file_fied" name="file_fied" type="file" />
+        <input id="id_file_field" name="file_field" type="file" />
     </div>
 </div>
 

--- a/bootstrapform/fixtures/horizontal_old.html
+++ b/bootstrapform/fixtures/horizontal_old.html
@@ -67,10 +67,10 @@
 </div>
 
 <div class="form-group">
-    <label class="control-label col-sm-2 col-lg-2 " for="id_file_fied">File fied</label>
+    <label class="control-label col-sm-2 col-lg-2 " for="id_file_field">File field</label>
     
     <div class=" col-sm-10 col-lg-10 ">
-        <input id="id_file_fied" name="file_fied" type="file" />
+        <input id="id_file_field" name="file_field" type="file" />
     </div>
 </div>
 

--- a/bootstrapform/tests.py
+++ b/bootstrapform/tests.py
@@ -28,7 +28,7 @@ class ExampleForm(forms.Form):
     radio_choice = forms.ChoiceField(choices=CHOICES, widget=forms.RadioSelect)
     multiple_choice = forms.MultipleChoiceField(choices=CHOICES)
     multiple_checkbox = forms.MultipleChoiceField(choices=CHOICES, widget=forms.CheckboxSelectMultiple)
-    file_fied = forms.FileField()
+    file_field = forms.FileField()
     password_field = forms.CharField(widget=forms.PasswordInput)
     textarea = forms.CharField(widget=forms.Textarea)
     boolean_field = forms.BooleanField()

--- a/example/app/forms.py
+++ b/example/app/forms.py
@@ -12,7 +12,7 @@ class ExampleForm(forms.Form):
     radio_choice = forms.ChoiceField(choices=CHOICES, widget=forms.RadioSelect)
     multiple_choice = forms.MultipleChoiceField(choices=CHOICES)
     multiple_checkbox = forms.MultipleChoiceField(choices=CHOICES, widget=forms.CheckboxSelectMultiple)
-    file_fied = forms.FileField()
+    file_field = forms.FileField()
     password_field = forms.CharField(widget=forms.PasswordInput)
     textarea = forms.CharField(widget=forms.Textarea)
     boolean_field = forms.BooleanField()


### PR DESCRIPTION
On the demo site, both basic and horizontal forms have the spelling "File fied" instead of "File field". These edits correct the typo.