### PR TITLE
Fix context for boundfields when Django version >= 1.8

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -77,8 +77,8 @@ def render(element, markup_classes):
             template = get_template("bootstrapform/form.html")
             context = Context({'form': element, 'classes': markup_classes})
 
-        if django_version >= (1, 8):
-            context = context.flatten()
+    if django_version >= (1, 8):
+        context = context.flatten()
 
     return template.render(context)
 


### PR DESCRIPTION
This commit https://github.com/tzangms/django-bootstrap-form/commit/7f97ef6b0d8a31a730650395a90c65e2f24e9cb2 didn't fix the case where the element type is a bound field. The deprecation warning `django.utils.deprecation.RemovedInDjango110Warning: render() must be called with a dict, not a Context` should be fixed now.
