### PR TITLE
Fix context flattening for django >= 1.8

### DIFF
--- a/bootstrapform/templatetags/bootstrap.py
+++ b/bootstrapform/templatetags/bootstrap.py
@@ -77,8 +77,8 @@ def render(element, markup_classes):
             template = get_template("bootstrapform/form.html")
             context = Context({'form': element, 'classes': markup_classes})
 
-        if django_version >= (1, 8):
-            context = context.flatten()
+    if django_version >= (1, 8):
+        context = context.flatten()
 
     return template.render(context)
 


### PR DESCRIPTION
Hello,

This fixes the context not being flattened in all cases, which results in an exception on Django 1.11