### PR TITLE
Add support for Python 3.6 and Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,76 @@
 language: python
 
-env:
-  matrix:
-    - TOX_ENV=py27-dj15
-    - TOX_ENV=py27-dj16
-    - TOX_ENV=py27-dj17
-    - TOX_ENV=py27-dj18
-    - TOX_ENV=py27-dj19
-    - TOX_ENV=py27-dj110
-    - TOX_ENV=py27-dj111
-    - TOX_ENV=py34-dj15
-    - TOX_ENV=py34-dj16
-    - TOX_ENV=py34-dj17
-    - TOX_ENV=py34-dj18
-    - TOX_ENV=py34-dj19
-    - TOX_ENV=py34-dj110
-    - TOX_ENV=py34-dj111
+matrix:
+  include:
+    - python: 2.7
+      env:
+        - TOX_ENV=py27-dj15
+    - python: 2.7
+      env:
+        - TOX_ENV=py27-dj16
+    - python: 2.7
+      env:
+        - TOX_ENV=py27-dj17
+    - python: 2.7
+      env:
+        - TOX_ENV=py27-dj18
+    - python: 2.7
+      env:
+        - TOX_ENV=py27-dj19
+    - python: 2.7
+      env:
+        - TOX_ENV=py27-dj110
+    - python: 2.7
+      env:
+        - TOX_ENV=py27-dj111
+    - python: 2.7
+      env:
+        - TOX_ENV=py34-dj15
+    - python: 3.4
+      env:
+        - TOX_ENV=py34-dj16
+    - python: 3.4
+      env:
+        - TOX_ENV=py34-dj17
+    - python: 3.4
+      env:
+        - TOX_ENV=py34-dj18
+    - python: 3.4
+      env:
+        - TOX_ENV=py34-dj19
+    - python: 3.4
+      env:
+        - TOX_ENV=py34-dj110
+    - python: 3.4
+      env:
+        - TOX_ENV=py34-dj111
+    - python: 3.4
+      env:
+        - TOX_ENV=py34-dj20
+    - python: 3.5
+      env:
+        - TOX_ENV=py35-dj18
+    - python: 3.5
+      env:
+        - TOX_ENV=py35-dj19
+    - python: 3.5
+      env:
+        - TOX_ENV=py35-dj110
+    - python: 3.5
+      env:
+        - TOX_ENV=py35-dj111
+    - python: 3.5
+      env:
+        - TOX_ENV=py35-dj20
+    - python: 3.6
+      env:
+        - TOX_ENV=py36-dj110
+    - python: 3.6
+      env:
+        - TOX_ENV=py36-dj111
+    - python: 3.6
+      env:
+        - TOX_ENV=py36-dj20
 
 install:
   - pip install tox coverage coveralls

--- a/runtests.py
+++ b/runtests.py
@@ -6,7 +6,24 @@ from os.path import dirname, abspath
 
 from django.conf import settings
 
+middleware = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    )
 
+
+if django.VERSION < (1, 10):
+    middleware_arg = {
+        'MIDDLEWARE_CLASSES': middleware,
+    }
+else:
+    middleware_arg = {
+        'MIDDLEWARE': middleware,
+    }
 
 settings.configure(
     DATABASES = {
@@ -23,22 +40,22 @@ settings.configure(
         'django.contrib.sites',
         'bootstrapform',
     ],
-    MIDDLEWARE_CLASSES = (
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    ),
     SITE_ID=1,
     DEBUG=False,
     ROOT_URLCONF='',
     TEMPLATES = [  # For >= Django 1.10
-        {'BACKEND': 'django.template.backends.django.DjangoTemplates', 'APP_DIRS': True},
-    ]
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.contrib.auth.context_processors.auth',
+                ],
+            },
+        },
+    ],
+    **middleware_arg
 )
-
 
 
 def runtests(**test_args):

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
     keywords='bootstrap,django',
     author='tzangms',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,6 @@
+import django
 import os
+
 local_path = lambda path: os.path.join(os.path.dirname(__file__), path)
 
 DATABASES = {
@@ -10,11 +12,18 @@ DATABASES = {
 
 SITE_ID = 1
 
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-)
+if django.VERSION < (1, 10):
+    MIDDLEWARE_CLASSES = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+    )
+else:
+    MIDDLEWARE = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+    )
 
 INSTALLED_APPS = [
     'django.contrib.contenttypes',
@@ -43,5 +52,20 @@ STATICFILES_FINDERS = (
 TEMPLATE_DIRS = (
     local_path('templates'),
 )
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': [
+            local_path('templates'),
+        ],
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+            ],
+        },
+    },
+]
 
 SECRET_KEY = 'django-bootstrap-form'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34}-dj{15,16,17,18,19,110,111}
+envlist = {py27,py34,py35,py36}-dj{15,16,17,18,19,110,111,20}
 skipsdist=True
 
 
@@ -7,6 +7,8 @@ skipsdist=True
 basepython =
     py27: python2.7
     py34: python3.4
+    py35: python3.5
+    py36: python3.6
 deps = 
     pytest
     dj15: django>=1.5,<1.6
@@ -16,6 +18,7 @@ deps =
     dj19: django>=1.9,<1.10
     dj110: django>=1.10,<1.11
     dj111: django>=1.10,<1.11
+    dj20: django>=2.0,<2.1
 commands = python setup.py test
 
 


### PR DESCRIPTION
Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>

Debian is moving to Django 2.0 soon and django-bootstrap-form needs to work with Django 2.0. Many applications such as FreedomBox using will have problem otherwise.

Please merge this patch and make a new release so that we can package for Debian immediately. Thank you in advance.