### PR TITLE
Refactor version handling to use packaging.version

### DIFF
--- a/bootstrapform/meta.py
+++ b/bootstrapform/meta.py
@@ -1,5 +1,3 @@
-from distutils.version import StrictVersion
+from packaging.version import Version
 
-
-VERSION = StrictVersion('3.4')
-
+VERSION = Version("3.4")

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 from bootstrapform.meta import VERSION
 
 setup(
-    name='django-bootstrap-form',
+    name="django-bootstrap-form",
     version=str(VERSION),
     description="django-bootstrap-form",
     classifiers=[
@@ -17,15 +18,13 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
-    keywords='bootstrap,django',
-    author='tzangms',
-    author_email='tzangms@gmail.com',
-    url='http://github.com/tzangms/django-bootstrap-form',
-    license='MIT',
-    test_suite='runtests.runtests',
-    install_requires = [
-        "django>=1.5",
-    ],
+    keywords="bootstrap,django",
+    author="tzangms",
+    author_email="tzangms@gmail.com",
+    url="http://github.com/tzangms/django-bootstrap-form",
+    license="MIT",
+    test_suite="runtests.runtests",
+    install_requires=["django>=1.5", "packaging>=20.0"],
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Fix compatibility with Python >=3.12

Didn't author the change, I just saw that @gabrielassed didn't create a pull request themselves.